### PR TITLE
Fix text being cut off in make-hollow dialog

### DIFF
--- a/dialogs/MakeHollow.cpp
+++ b/dialogs/MakeHollow.cpp
@@ -11,7 +11,7 @@ CMakeHollow::CMakeHollow(QWidget* pParent) :
 	QDialog(pParent)
 {
 	this->setWindowTitle(tr("Hammer"));
-	this->setFixedSize(280, 100);
+	this->setFixedSize(280, 145);
 
 	auto pDialogLayout = new QVBoxLayout(this);
 	pDialogLayout->setAlignment(Qt::AlignLeft);


### PR DESCRIPTION
fixes https://github.com/ChaosInitiative/hammer-qt-dialogs/issues/52

![image](https://user-images.githubusercontent.com/62961532/135547391-cb8a0907-2d1b-4a4c-8a5c-1f79f3f8dd65.png)
