### PR TITLE
fix: Transform dialog spacing and button size

### DIFF
--- a/dialogs/Transform.cpp
+++ b/dialogs/Transform.cpp
@@ -1,6 +1,7 @@
 #include "dialogs/Transform.h"
 
 #include <QGridLayout>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QDoubleValidator>
 #include <QPushButton>
@@ -25,15 +26,26 @@ CTransform::CTransform( QWidget *pParent ) :
 	m_pScale = new QRadioButton( tr( "Scale" ), this );
 	m_pMove = new QRadioButton( tr( "Move" ), this );
 
+	auto pXLayout = new QHBoxLayout( this );
 	auto pXLabel = new QLabel( "X:", this );
 	m_pXValue = new QLineEdit( "0", this );
 	m_pXValue->setValidator( new QDoubleValidator( m_pXValue ) );
+	pXLayout->addWidget( pXLabel );
+	pXLayout->addWidget( m_pXValue );
+
+	auto pYLayout = new QHBoxLayout( this );
 	auto pYLabel = new QLabel( "Y:", this );
 	m_pYValue = new QLineEdit( "0", this );
 	m_pYValue->setValidator( new QDoubleValidator( m_pYValue ) );
+	pYLayout->addWidget( pYLabel );
+	pYLayout->addWidget( m_pYValue );
+
+	auto pZLayout = new QHBoxLayout( this );
 	auto pZLabel = new QLabel( "Z:", this );
 	m_pZValue = new QLineEdit( "0", this );
 	m_pZValue->setValidator( new QDoubleValidator( m_pZValue ) );
+	pZLayout->addWidget( pZLabel );
+	pZLayout->addWidget( m_pZValue );
 
 	// Add widgets to the grid layout
 	int row = 0;
@@ -45,20 +57,17 @@ CTransform::CTransform( QWidget *pParent ) :
 
 	//1
 	pDialogLayout->addWidget( m_pRotate, row, 0 );
-	pDialogLayout->addWidget( pXLabel, row, 0, Qt::AlignRight );
-	pDialogLayout->addWidget( m_pXValue, row, 1 );
+	pDialogLayout->addLayout( pXLayout, row, 1 );
 	row++;
 
 	//2
 	pDialogLayout->addWidget( m_pScale, row, 0 );
-	pDialogLayout->addWidget( pYLabel, row, 0, Qt::AlignRight );
-	pDialogLayout->addWidget( m_pYValue, row, 1 );
+	pDialogLayout->addLayout( pYLayout, row, 1 );
 	row++;
 
 	//3
 	pDialogLayout->addWidget( m_pMove, row, 0 );
-	pDialogLayout->addWidget( pZLabel, row, 0, Qt::AlignRight );
-	pDialogLayout->addWidget( m_pZValue, row, 1 );
+	pDialogLayout->addLayout( pZLayout, row, 1 );
 	row++;
 
 	//4

--- a/dialogs/Transform.cpp
+++ b/dialogs/Transform.cpp
@@ -4,6 +4,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QDoubleValidator>
+#include <QDialogButtonBox>
 #include <QPushButton>
 
 using namespace ui;
@@ -15,8 +16,9 @@ CTransform::CTransform( QWidget *pParent ) :
 
 	auto pDialogLayout = new QGridLayout( this );
 
-	auto pOkButton = new QPushButton( tr( "Ok" ), this );
-	auto pCancelButton = new QPushButton( tr( "Cancel" ), this );
+	auto pButtonBox = new QDialogButtonBox( this );
+	auto pOkButton = pButtonBox->addButton( QDialogButtonBox::Ok );
+	auto pCancelButton = pButtonBox->addButton( QDialogButtonBox::Cancel );
 
 	auto pModeLabel = new QLabel( "Mode:", this );
 	auto pValueLabel = new QLabel( "Values:", this );
@@ -71,8 +73,7 @@ CTransform::CTransform( QWidget *pParent ) :
 	row++;
 
 	//4
-	pDialogLayout->addWidget( pOkButton, row, 0 );
-	pDialogLayout->addWidget( pCancelButton, row, 1 );
+	pDialogLayout->addWidget( pButtonBox, row, 0, 1, 2, Qt::AlignCenter );;
 
 	this->setLayout( pDialogLayout );
 


### PR DESCRIPTION
This is just a follow-up fix to the spacing and button size.

![image](https://user-images.githubusercontent.com/28122025/143768018-32a89deb-7f27-4189-8301-6104a9d1866c.png)
